### PR TITLE
#64 前後の月の日付を選択して月遷移した際にヘッダー部に反映されないバグ修正

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -126,6 +126,7 @@ const CalendarComponent = () => {
 	};
 
 	const onPanelChange = (value) => {
+		setCurrentDate(value);
 		setCurrentMonth(value);
 	};
 


### PR DESCRIPTION
既存への影響の考慮漏れ
onPanelChangeを呼んだ時にもvalueを変更できるようにした。
